### PR TITLE
mutable cleave options in bs4_form.ml, fixes in cleave.ml

### DIFF
--- a/libs/ocplib-bs4/bs4_form.ml
+++ b/libs/ocplib-bs4/bs4_form.ml
@@ -231,18 +231,17 @@ module Make(S : sig
         | _ -> ()) !fields
 
   let update_cleave ~id ~maker ~cleave_option =
-    List.iter (function field ->
-      match field with
+    List.iter (function
       | f when f.id = id ->
         let cleave = maker ("#" ^ id ^ "-input") in
         begin
-        if cleave_option = "date" then
-          field.getter <- fun _ -> Cleave.iso_date cleave;
-        else
-          field.getter <- fun _ -> Cleave.value cleave
-      end;
-        field.maker <- Some maker;
-        field.cleave_option <- Some cleave_option
+          if cleave_option = "date" then
+            f.getter <- fun _ -> Cleave.iso_date cleave
+          else
+            f.getter <- fun _ -> Cleave.value cleave
+        end;
+        f.maker <- Some maker;
+        f.cleave_option <- Some cleave_option
 
       | _ -> ()) !fields
 

--- a/libs/ocplib-bs4/bs4_form.ml
+++ b/libs/ocplib-bs4/bs4_form.ml
@@ -79,8 +79,8 @@ type status =
 
 type field = {
   id : string;
-  cleave_option : string option;
-  maker : (string -> Cleave.cleave Js.t) option;
+  mutable cleave_option : string option;
+  mutable maker : (string -> Cleave.cleave Js.t) option;
   checker : (string -> string option) option;
   mutable getter : string -> string;
 }
@@ -229,6 +229,23 @@ module Make(S : sig
           else
             field.getter <- fun _ -> Cleave.value cleave
         | _ -> ()) !fields
+
+  let update_cleave ~id ~maker ~cleave_option =
+    List.iter (function field ->
+      match field with
+      | f when f.id = id ->
+        let cleave = maker ("#" ^ id ^ "-input") in
+        begin
+        if cleave_option = "date" then
+          field.getter <- fun _ -> Cleave.iso_date cleave;
+        else
+          field.getter <- fun _ -> Cleave.value cleave
+      end;
+        field.maker <- Some maker;
+        field.cleave_option <- Some cleave_option
+
+      | _ -> ()) !fields
+
 
 
 end

--- a/libs/ocplib-cleave/cleave.ml
+++ b/libs/ocplib-cleave/cleave.ml
@@ -56,7 +56,7 @@ let raw_options () : options Js.t = Js.Unsafe.obj [||]
 let general_options ?(blocks=[]) ?(delimiter=" ") ?(delimiters=[])
     ?(delimiter_lazy=false) ?(prefix=None) ?(no_immediate_prefix=false)
     ?(raw_value_trim_prefix=false) ?(numeric=false)
-    ?(uppercase=false) ?(lowercase=false) ?(onchange=(fun _ -> ()) options =
+    ?(uppercase=false) ?(lowercase=false) ?(onchange=(fun _ -> ())) options =
   options##blocks <- Js.array (Array.of_list blocks);
   options##delimiter <- Js.string delimiter;
   options##delimieters <- Js.array (Array.of_list @@ List.map Js.string delimiters);

--- a/libs/ocplib-cleave/cleave.ml
+++ b/libs/ocplib-cleave/cleave.ml
@@ -4,6 +4,7 @@ type string_field = Js.js_string Js.t Js.prop
 type int_field = int Js.prop
 type bool_field = bool Js.prop
 type string_array_field = Js.js_string Js.t Js.js_array Js.t Js.prop
+type int_array_field = int Js.js_array Js.t Js.prop
 type string_meth = Js.js_string Js.t Js.meth
 type unit_meth = unit Js.meth
 
@@ -25,7 +26,7 @@ class type options = object
   method numeralDecimalMark : string_field
   method numeralPositiveOnly : bool_field
   method stripLeadingZeroes : bool_field
-  method blocks : int_field
+  method blocks : int_array_field
   method delimiter : string_field
   method delimiters : string_array_field
   method delimiterlazyshow : bool_field
@@ -53,9 +54,9 @@ let cleave : (Js.js_string Js.t -> options Js.t -> cleave Js.t) Js.constr =
 let raw_options () : options Js.t = Js.Unsafe.obj [||]
 
 let general_options ?(blocks=[]) ?(delimiter=" ") ?(delimiters=[])
-    ?(delimiter_lazy) ?prefix ?(no_immediate_prefix=false)
+    ?(delimiter_lazy=false) ?(prefix=None) ?(no_immediate_prefix=false)
     ?(raw_value_trim_prefix=false) ?(numeric=false)
-    ?(uppercase=false) ?(lowercase=false) ?onchange options =
+    ?(uppercase=false) ?(lowercase=false) ?(onchange=(fun _ -> ()) options =
   options##blocks <- Js.array (Array.of_list blocks);
   options##delimiter <- Js.string delimiter;
   options##delimieters <- Js.array (Array.of_list @@ List.map Js.string delimiters);
@@ -68,7 +69,7 @@ let general_options ?(blocks=[]) ?(delimiter=" ") ?(delimiters=[])
   options##onValueChanged <- onchange;
   match prefix with
   | None -> ()
-  | Some prefix -> options##prefix <- prefix
+  | Some prefix -> options##prefix <- Js.string prefix
 
 let make_card ?(strict_mode=false) ?onchange ?gen_opt selector =
   let options = raw_options () in


### PR DESCRIPTION
In `bs4_form.ml`
- Changed `maker` and `cleave_option` in the `field` record to `mutable`;
- Added a function `update_cleave` that modifies the way a field is cleaved in a form;
In `cleave.ml`: 
- added a `int_array_field` type
- modified `blocks` to be indeed a `int_array_field` instead of an `int_field`
- added default options in `gen_opt` 