### PR TITLE
Adding session utilities to ocplib-jsutils

### DIFF
--- a/libs/ocplib-utils/build.ocp2
+++ b/libs/ocplib-utils/build.ocp2
@@ -9,6 +9,7 @@ OCaml.library("ocplib-utils-js", ocaml + {
     "jsloc.ml", pp_js;
     "jsStorage.ml", pp_js;
     "cookie", pp_js;
+    "session.ml", pp_js;
     "jslang.ml";
     "onload.ml", pp_js;
     "jsdate.ml", pp_js

--- a/libs/ocplib-utils/session.ml
+++ b/libs/ocplib-utils/session.ml
@@ -1,0 +1,36 @@
+open Ocp_js
+
+let get_session () = Js.Optdef.to_option (Dom_html.window##.sessionStorage)
+
+let get_value key =
+  let key' = Js.string key in
+  match get_session () with
+  | None ->
+    Js_utils.log "Session not found while getting value";
+    None
+  | Some session -> begin
+      match Js.Opt.to_option (session##getItem key') with
+      | None -> None
+      | Some s ->
+        let result = Js.to_string s in
+        Some result
+    end
+
+let set_value key value =
+  match get_session () with
+  | None -> Js_utils.log "Session not found while setting value"
+  | Some session ->
+    let key   = Js.string key   in
+    let value = Js.string value in
+    session##setItem key value
+
+let remove_value key =
+  let key' = Js.string key in
+  match get_session () with
+  | None ->
+    Js_utils.log "Session not found while removing value"
+  | Some session -> begin
+      match Js.Opt.to_option (session##getItem key') with
+      | None -> ()
+      | Some _ -> session##removeItem key'
+    end


### PR DESCRIPTION
This PR adds some utilities for handling sessions.

- `get_session` : returns the current session
- `get_value key` : returns the optional valut bounded to `key` in the current session.
- `set_value key value` : updates the session with the binding (key, value)
- `remove_value key` : remove the binding with `key` as key